### PR TITLE
feat(ios): implement close

### DIFF
--- a/OSInAppBrowserLib/RouterAdapters/OSIABSafariViewControllerRouterAdapter.swift
+++ b/OSInAppBrowserLib/RouterAdapters/OSIABSafariViewControllerRouterAdapter.swift
@@ -23,11 +23,11 @@ public class OSIABSafariViewControllerRouterAdapter: NSObject, OSIABRouter {
     }
     
     public func handleOpen(_ url: URL, _ completionHandler: @escaping (ReturnType) -> Void) {
-        let configurations = SFSafariViewController.Configuration()
-        configurations.barCollapsingEnabled = self.options.enableBarsCollapsing
-        configurations.entersReaderIfAvailable =  self.options.enableReadersMode
+        let configuration = SFSafariViewController.Configuration()
+        configuration.barCollapsingEnabled = self.options.enableBarsCollapsing
+        configuration.entersReaderIfAvailable =  self.options.enableReadersMode
         
-        let safariViewController = SFSafariViewController(url: url, configuration: configurations)
+        let safariViewController = OSIABSafariViewController(url, configuration, dismiss: { self.onBrowserClosed() })
         safariViewController.dismissButtonStyle = self.options.dismissButtonStyle
         safariViewController.modalPresentationStyle = self.options.modalPresentationStyle
         safariViewController.modalTransitionStyle = self.options.modalTransitionStyle
@@ -46,15 +46,27 @@ extension OSIABSafariViewControllerRouterAdapter: SFSafariViewControllerDelegate
             self.onBrowserPageLoad()
         }
     }
-    
-    public func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
-        self.onBrowserClosed()
-    }
 }
 
 // MARK: - UIAdaptivePresentationControllerDelegate implementation
 extension OSIABSafariViewControllerRouterAdapter: UIAdaptivePresentationControllerDelegate {
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         self.onBrowserClosed()
+    }
+}
+
+private class OSIABSafariViewController: SFSafariViewController {
+    let dismiss: () -> Void
+    
+    init(_ url: URL, _ configuration: Configuration, dismiss: @escaping () -> Void) {
+        self.dismiss = dismiss
+        super.init(url: url, configuration: configuration)
+    }
+    
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        super.dismiss(animated: flag, completion: {
+            self.dismiss()
+            completion?()
+        })
     }
 }

--- a/OSInAppBrowserLibTests/OSIABSafariViewControllerRouterAdapterTests.swift
+++ b/OSInAppBrowserLibTests/OSIABSafariViewControllerRouterAdapterTests.swift
@@ -133,9 +133,7 @@ final class OSIABSafariVCRouterAdapterTests: XCTestCase {
     func test_handleOpen_withBrowserClosedConfigured_eventShouldBeTriggeredWhenClosed() {
         let expectation = self.expectation(description: "Trigger onBrowserClose Event")
         makeSUT(onBrowserClosed: { expectation.fulfill() }).handleOpen(validURL) {
-            if let safariViewController = $0 as? SFSafariViewController {
-                safariViewController.delegate?.safariViewControllerDidFinish?(safariViewController)
-            }
+            $0.dismiss(animated: false)
         }
         waitForExpectations(timeout: 1)
     }

--- a/OSInAppBrowserLibTests/OSIABWebViewRouterAdapterTests.swift
+++ b/OSInAppBrowserLibTests/OSIABWebViewRouterAdapterTests.swift
@@ -113,6 +113,19 @@ final class OSIABWebViewRouterAdapterTests: XCTestCase {
         waitForExpectations(timeout: 1)
         XCTAssertTrue(isBrowserAlreadyClosed)
     }
+    
+    func test_handleOpen_whenDismissingViewController_eventShouldBeTriggered() {
+        var isBrowserAlreadyClosed = false
+        let expectation = self.expectation(description: "Trigger onBrowserClose Event")
+        makeSUT { param in
+            isBrowserAlreadyClosed = param
+            expectation.fulfill()
+        }.handleOpen(validURL) {
+            $0.dismiss(animated: false)
+        }
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(isBrowserAlreadyClosed)
+    }
 }
 
 private extension OSIABWebViewRouterAdapterTests {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -22,3 +22,4 @@ sonar.tests=OSInAppBrowserLibTests
 sonar.swift.project=OSInAppBrowserLib.xcodeproj
 sonar.swift.appScheme=OSInAppBrowserLib
 
+sonar.scm.disabled=true


### PR DESCRIPTION
This is applied to the Router's concrete implementations. To achieve this, a specific subclass was created where the 'dismiss' method is override to return the 'onBrowserClosed' callback. With this, previously used methods that did similar were removed (safariViewControllerDidFinish). Create method accelerators to transform OSIABWebViewOptions to OSIABWebViewConfigurationModel and OSIABWebViewUIModel. Update unit tests.

References: https://outsystemsrd.atlassian.net/browse/RMET-3427

## Description
<!--- Describe your changes in detail -->

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality not to work as expected)

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows the code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
