### PR TITLE
RMET-3427 ::: Close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Features
+- Add `Close` feature (https://outsystemsrd.atlassian.net/browse/RMET-3427).
 - Add `OpenInWebView`'s interface customisations (https://outsystemsrd.atlassian.net/browse/RMET-3489).
 - Add `OpenInWebView`'s event listeners (https://outsystemsrd.atlassian.net/browse/RMET-3430).
 - Add `OpenInWebView`'s features (https://outsystemsrd.atlassian.net/browse/RMET-3425).

--- a/OSInAppBrowserLib/RouterAdapters/OSIABWebViewRouterAdapter.swift
+++ b/OSInAppBrowserLib/RouterAdapters/OSIABWebViewRouterAdapter.swift
@@ -34,29 +34,16 @@ public class OSIABWebViewRouterAdapter: NSObject, OSIABRouter {
             self.cacheManager.clearSessionCache()
         }
         
-        let configurationModel = OSIABWebViewConfigurationModel(
-            self.options.mediaTypesRequiringUserActionForPlayback,
-            self.options.enableViewportScale,
-            self.options.allowInLineMediaPlayback,
-            self.options.surpressIncrementalRendering
-        )
-        let uiModel = OSIABWebViewUIModel(
-            showURL: self.options.showURL,
-            showToolbar: self.options.showToolbar,
-            toolbarPosition: self.options.toolbarPosition,
-            showNavigationButtons: self.options.showNavigationButtons,
-            leftToRight: self.options.leftToRight,
-            closeButtonText: self.options.closeButtonText
-        )
         let viewModel = OSIABWebViewModel(
             url: url,
-            configurationModel.toWebViewConfiguration(),
+            self.options.toConfigurationModel().toWebViewConfiguration(),
             self.options.allowOverScroll,
             self.options.customUserAgent,
-            uiModel: uiModel,
+            uiModel: self.options.toUIModel(),
             callbackHandler: self.callbackHandler
         )
-        let hostingController = UIHostingController(rootView: OSIABWebViewWrapper(viewModel))
+        
+        let hostingController = OSIABWebViewController(rootView: .init(viewModel), dismiss: { self.callbackHandler.onBrowserClosed(true) })
         hostingController.modalPresentationStyle = self.options.modalPresentationStyle
         hostingController.modalTransitionStyle = self.options.modalTransitionStyle
         hostingController.presentationController?.delegate = self
@@ -65,9 +52,63 @@ public class OSIABWebViewRouterAdapter: NSObject, OSIABRouter {
     }
 }
 
+// MARK: - Accelerator methods.
+private extension OSIABWebViewOptions {
+    /// Converts the current value to `OSIABWebViewConfigurationModel` equivalent.
+    /// - Returns: The `OSIABWebViewConfigurationModel` equivalent value.
+    func toConfigurationModel() -> OSIABWebViewConfigurationModel {
+        .init(
+            self.mediaTypesRequiringUserActionForPlayback,
+            self.enableViewportScale,
+            self.allowInLineMediaPlayback,
+            self.surpressIncrementalRendering
+        )
+    }
+    
+    /// Converts the current value to `OSIABWebViewUIModel` equivalent.
+    /// - Returns: The `OSIABWebViewUIModel` equivalent value.
+    func toUIModel() -> OSIABWebViewUIModel {
+        .init(
+            showURL: self.showURL,
+            showToolbar: self.showToolbar,
+            toolbarPosition: self.toolbarPosition,
+            showNavigationButtons: self.showNavigationButtons,
+            leftToRight: self.leftToRight,
+            closeButtonText: self.closeButtonText
+        )
+    }
+}
+
 // MARK: - UIAdaptivePresentationControllerDelegate implementation
 extension OSIABWebViewRouterAdapter: UIAdaptivePresentationControllerDelegate {
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         self.callbackHandler.onBrowserClosed(true)
+    }
+}
+
+/// A subclass for `UIHostingController` where it's possible to delegate the `dismiss` call to its callers.
+private class OSIABWebViewController: UIHostingController<OSIABWebViewWrapper> {
+    /// Callback to trigger when the view controller is closed.
+    let dismiss: (() -> Void)?
+    
+    /// Constructor method.
+    /// - Parameters:
+    ///   - rootView: The root view of the SwiftUI view hierarchy that you want to manage using the hosting view controller.
+    ///   - dismiss: The callback to trigger when the view controller is dismissed.
+    init(rootView: OSIABWebViewWrapper, dismiss: (() -> Void)?) {
+        self.dismiss = dismiss
+        super.init(rootView: rootView)
+    }
+    
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        self.dismiss = nil
+        super.init(coder: aDecoder)
+    }
+    
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        super.dismiss(animated: flag, completion: {
+            self.dismiss?()
+            completion?()
+        })
     }
 }

--- a/OSInAppBrowserLibTests/OSIABSafariViewControllerRouterAdapterTests.swift
+++ b/OSInAppBrowserLibTests/OSIABSafariViewControllerRouterAdapterTests.swift
@@ -133,9 +133,7 @@ final class OSIABSafariVCRouterAdapterTests: XCTestCase {
     func test_handleOpen_withBrowserClosedConfigured_eventShouldBeTriggeredWhenClosed() {
         let expectation = self.expectation(description: "Trigger onBrowserClose Event")
         makeSUT(onBrowserClosed: { expectation.fulfill() }).handleOpen(validURL) {
-            if let safariViewController = $0 as? SFSafariViewController {
-                safariViewController.delegate?.safariViewControllerDidFinish?(safariViewController)
-            }
+            $0.dismiss(animated: false)
         }
         waitForExpectations(timeout: 1)
     }

--- a/OSInAppBrowserLibTests/OSIABWebViewRouterAdapterTests.swift
+++ b/OSInAppBrowserLibTests/OSIABWebViewRouterAdapterTests.swift
@@ -113,6 +113,19 @@ final class OSIABWebViewRouterAdapterTests: XCTestCase {
         waitForExpectations(timeout: 1)
         XCTAssertTrue(isBrowserAlreadyClosed)
     }
+    
+    func test_handleOpen_whenDismissingViewController_eventShouldBeTriggered() {
+        var isBrowserAlreadyClosed = false
+        let expectation = self.expectation(description: "Trigger onBrowserClose Event")
+        makeSUT { param in
+            isBrowserAlreadyClosed = param
+            expectation.fulfill()
+        }.handleOpen(validURL) {
+            $0.dismiss(animated: false)
+        }
+        waitForExpectations(timeout: 1)
+        XCTAssertTrue(isBrowserAlreadyClosed)
+    }
 }
 
 private extension OSIABWebViewRouterAdapterTests {


### PR DESCRIPTION
## Description
- This is applied to the Router's concrete implementations. To achieve this, a specific subclass was created where the 'dismiss' method is overridden to return the 'onBrowserClosed' callback. With this, previously used methods that did similar were removed (safariViewControllerDidFinish). 
- Create method accelerators to transform OSIABWebViewOptions to OSIABWebViewConfigurationModel and OSIABWebViewUIModel.

_Note: Not sure why SonarCloud is returning 0% coverage but it looks like a temporary issue._

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3427

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality not to work as expected)

## Tests
Unit tests to validate the implementation were added to the pipeline. All are passing successfully.

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows the code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
