### PR TITLE
RMET-4122 ::: Add onBrowserPageNavigationCompleted event

### DIFF
--- a/OSInAppBrowserLib/RouterAdapters/OSIABApplicationRouterAdapter.swift
+++ b/OSInAppBrowserLib/RouterAdapters/OSIABApplicationRouterAdapter.swift
@@ -9,7 +9,7 @@ public protocol OSIABApplicationDelegate: AnyObject {
 
 /// Provide a default implementations that abstracts the options parameter.
 extension OSIABApplicationDelegate {
-    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any] = [:], completionHandler completion: ((Bool) -> Void)?) {
+    public func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any] = [:], completionHandler completion: ((Bool) -> Void)?) {
         self.open(url, options: options, completionHandler: completion)
     }
 }

--- a/OSInAppBrowserLib/WebView/OSIABWebViewCallbackHandler.swift
+++ b/OSInAppBrowserLib/WebView/OSIABWebViewCallbackHandler.swift
@@ -10,7 +10,9 @@ public struct OSIABWebViewCallbackHandler {
     let onBrowserPageLoad: () -> Void
     /// Callback to trigger when the browser is closed. The boolean arguments indicates if the browser was already close or still needs to be.
     let onBrowserClosed: (Bool) -> Void
-    
+    /// Callback to trigger when the browser finishes navigation. The argument is the current URL.
+    let onBrowserPageNavigationCompleted: (String?) -> Void
+
     /// Constructor method.
     /// - Parameters:
     ///   - onDelegateURL: Callback to trigger when the an URL needs to be delegates to its callers.
@@ -21,11 +23,13 @@ public struct OSIABWebViewCallbackHandler {
         onDelegateURL: @escaping (URL) -> Void,
         onDelegateAlertController: @escaping (UIAlertController) -> Void,
         onBrowserPageLoad: @escaping () -> Void,
-        onBrowserClosed: @escaping (Bool) -> Void // boolean indicates if the browser is already closed.
+        onBrowserClosed: @escaping (Bool) -> Void, // boolean indicates if the browser is already closed.
+        onBrowserPageNavigationCompleted: @escaping (String?) -> Void
     ) {
         self.onDelegateURL = onDelegateURL
         self.onDelegateAlertController = onDelegateAlertController
         self.onBrowserPageLoad = onBrowserPageLoad
         self.onBrowserClosed = onBrowserClosed
+        self.onBrowserPageNavigationCompleted = onBrowserPageNavigationCompleted
     }
 }

--- a/OSInAppBrowserLib/WebView/OSIABWebViewModel.swift
+++ b/OSInAppBrowserLib/WebView/OSIABWebViewModel.swift
@@ -182,6 +182,8 @@ extension OSIABWebViewModel: WKNavigationDelegate {
         if !self.firstLoadDone {
             self.callbackHandler.onBrowserPageLoad()
             self.firstLoadDone = true
+        } else {
+            self.callbackHandler.onBrowserPageNavigationCompleted(url.absoluteString)
         }
         error = nil
     }

--- a/OSInAppBrowserLib/WebView/Views/OSIABWebView.swift
+++ b/OSInAppBrowserLib/WebView/Views/OSIABWebView.swift
@@ -96,7 +96,8 @@ private extension OSIABWebViewModel {
                 onDelegateURL: { _ in },
                 onDelegateAlertController: { _ in },
                 onBrowserPageLoad: {},
-                onBrowserClosed: onBrowserClosed
+                onBrowserClosed: onBrowserClosed,
+                onBrowserPageNavigationCompleted: { _ in }
             )
         )
     }

--- a/OSInAppBrowserLib/WebView/Views/OSIABWebView13WrapperView.swift
+++ b/OSInAppBrowserLib/WebView/Views/OSIABWebView13WrapperView.swift
@@ -58,7 +58,8 @@ private extension OSIABWebViewModel {
                 onDelegateURL: { _ in },
                 onDelegateAlertController: { _ in },
                 onBrowserPageLoad: {},
-                onBrowserClosed: { _ in }
+                onBrowserClosed: { _ in },
+                onBrowserPageNavigationCompleted: { _ in }
             )
         )
     }
@@ -73,7 +74,8 @@ private extension OSIABWebViewModel {
                 onDelegateURL: { _ in },
                 onDelegateAlertController: { _ in },
                 onBrowserPageLoad: {},
-                onBrowserClosed: { _ in }
+                onBrowserClosed: { _ in },
+                onBrowserPageNavigationCompleted:  { _ in }
             )
         )
     }

--- a/OSInAppBrowserLib/WebView/Views/OSIABWebViewWrapperView.swift
+++ b/OSInAppBrowserLib/WebView/Views/OSIABWebViewWrapperView.swift
@@ -35,7 +35,8 @@ private extension OSIABWebViewModel {
                 onDelegateURL: { _ in },
                 onDelegateAlertController: { _ in },
                 onBrowserPageLoad: {},
-                onBrowserClosed: { _ in }
+                onBrowserClosed: { _ in },
+                onBrowserPageNavigationCompleted: { _ in }
             )
         )
     }
@@ -50,7 +51,8 @@ private extension OSIABWebViewModel {
                 onDelegateURL: { _ in },
                 onDelegateAlertController: { _ in },
                 onBrowserPageLoad: {},
-                onBrowserClosed: { _ in }
+                onBrowserClosed: { _ in },
+                onBrowserPageNavigationCompleted: { _ in }
             )
         )
     }

--- a/OSInAppBrowserLibTests/OSIABViewModelTests.swift
+++ b/OSInAppBrowserLibTests/OSIABViewModelTests.swift
@@ -181,6 +181,20 @@ final class OSIABViewModelTests: XCTestCase {
         XCTAssertEqual(resultAction, .allow)
     }
     
+    func test_navigateToNewPage_onBrowserPageNavigationCompletedEventShouldBeTrigged() {
+        var result: String? = nil
+        let expectation = self.expectation(description: "Trigger onBrowserPageNavigationCompleted Event")
+
+        let sut = makeSUT(url, onBrowserPageNavigationCompleted: { data in
+            result = data
+            expectation.fulfill()
+        })
+        sut.webView(sut.webView, didFinish: nil)
+        sut.webView(sut.webView, didFinish: nil)
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(url.absoluteString, result)
+    }
+    
     // MARK: Browser Page Load Event Tests
     
     func test_navigateToURL_whenFinished_triggerPageLoadEventOnFirstTime() {
@@ -275,7 +289,8 @@ private extension OSIABViewModelTests {
         onDelegateURL: @escaping (URL) -> Void = { _ in },
         onDelegateAlertController: @escaping (UIAlertController) -> Void = { _ in },
         onBrowserPageLoad: @escaping () -> Void = {},
-        onBrowserClosed: @escaping (Bool) -> Void = { _ in }
+        onBrowserClosed: @escaping (Bool) -> Void = { _ in },
+        onBrowserPageNavigationCompleted: @escaping (String?) -> Void = { _ in }
     ) -> OSIABWebViewModel {
         let configurationModel = OSIABWebViewConfigurationModel(
             mediaTypesRequiringUserActionForPlayback, ignoresViewportScaleLimits, allowsInlineMediaPlayback, surpressesIncrementalRendering
@@ -297,7 +312,8 @@ private extension OSIABViewModelTests {
                 onDelegateURL: onDelegateURL,
                 onDelegateAlertController: onDelegateAlertController,
                 onBrowserPageLoad: onBrowserPageLoad,
-                onBrowserClosed: onBrowserClosed
+                onBrowserClosed: onBrowserClosed,
+                onBrowserPageNavigationCompleted: onBrowserPageNavigationCompleted
             )
         )
     }

--- a/OSInAppBrowserLibTests/OSIABWebViewRouterAdapterTests.swift
+++ b/OSInAppBrowserLibTests/OSIABWebViewRouterAdapterTests.swift
@@ -141,7 +141,8 @@ private extension OSIABWebViewRouterAdapterTests {
                 onDelegateURL: { _ in },
                 onDelegateAlertController: { _ in },
                 onBrowserPageLoad: {},
-                onBrowserClosed: onBrowserClosed
+                onBrowserClosed: onBrowserClosed,
+                onBrowserPageNavigationCompleted: { _ in }
             )
         )
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR adds the event onBrowserPageNavigationCompleted, which is triggered when the user navigates on the web view.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
https://outsystemsrd.atlassian.net/browse/RMET-4122

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality not to work as expected)

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
`test_navigateToNewPage_onBrowserPageNavigationCompletedEventShouldBeTrigged`

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows the code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
