### PR TITLE
fix: WebView close button error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixes
+
+- Fixes an issue where dismissing an alert view triggered the onBrowserClosed event. [RMET-4500](https://outsystemsrd.atlassian.net/browse/RMET-4500).
+
 ## 2.2.0
 
 ### Features

--- a/Sources/OSInAppBrowserLib/RouterAdapters/OSIABWebViewRouterAdapter.swift
+++ b/Sources/OSInAppBrowserLib/RouterAdapters/OSIABWebViewRouterAdapter.swift
@@ -121,10 +121,14 @@ private class OSIABWebViewController: UIHostingController<OSIABWebViewWrapperVie
     }
     
     override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        super.dismiss(animated: flag, completion: {
+        guard presentedViewController == nil else {
+            return super.dismiss(animated: flag, completion: completion)
+        }
+        
+        super.dismiss(animated: flag) {
             self.dismiss?()
             completion?()
-        })
+        }
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes an issue where dismissing an alert view triggered the onBrowserClosed event.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
https://outsystemsrd.atlassian.net/browse/RMET-4500

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality not to work as expected)

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows the code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
