### PR TITLE
RMET-5110 ::: added fix do allow open url InAppBrowser and download a file

### DIFF
--- a/Sources/OSInAppBrowserLib/Models/OSIABWebViewConfigurationModel.swift
+++ b/Sources/OSInAppBrowserLib/Models/OSIABWebViewConfigurationModel.swift
@@ -36,6 +36,16 @@ struct OSIABWebViewConfigurationModel {
         configuration.ignoresViewportScaleLimits = ignoresViewportScaleLimits
         configuration.allowsInlineMediaPlayback = allowsInlineMediaPlayback
         configuration.suppressesIncrementalRendering = suppressesIncrementalRendering
+        let windowOpenScript = WKUserScript(
+            source: """
+            window.open = function(url, target, features) {
+                if (url) { window.location.href = url; }
+            };
+            """,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: false
+        )
+        configuration.userContentController.addUserScript(windowOpenScript)
         return configuration
     }
 }

--- a/Sources/OSInAppBrowserLib/WebView/OSIABWebViewModel.swift
+++ b/Sources/OSInAppBrowserLib/WebView/OSIABWebViewModel.swift
@@ -19,6 +19,12 @@ class OSIABWebViewModel: NSObject, ObservableObject {
     
     /// Indicates if first load is already done. This is important in order to trigger the `browserPageLoad` event.
     private var firstLoadDone: Bool = false
+    /// Indicates if a download is in progress, to suppress navigation errors caused by download redirects.
+    private var isDownloadInProgress: Bool = false
+    /// Retains the active WKDownload to prevent it from being deallocated mid-download.
+    private var activeDownload: AnyObject?
+    /// Stores the destination URL for the active download.
+    private var downloadDestinationURL: URL?
     
     /// Custom headers to be used by the WebView.
     private let customHeaders: [String: String]?
@@ -206,6 +212,18 @@ extension OSIABWebViewModel: WKNavigationDelegate {
         }
     }
     
+    @available(iOS 14.5, *)
+    func webView(_ webView: WKWebView, navigationAction: WKNavigationAction, didBecome download: WKDownload) {
+        download.delegate = self
+    }
+
+    @available(iOS 14.5, *)
+    func webView(_ webView: WKWebView, navigationResponse: WKNavigationResponse, didBecome download: WKDownload) {
+        isDownloadInProgress = true
+        activeDownload = download
+        download.delegate = self
+    }
+
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         if !firstLoadDone {
             callbackHandler.onBrowserPageLoad()
@@ -225,10 +243,66 @@ extension OSIABWebViewModel: WKNavigationDelegate {
     }
     
     private func handleWebViewNavigationError(_ delegateName: String, error: Error) {
-        print("webView: \(delegateName) - \(error.localizedDescription)")
-        if (error as NSError).code != NSURLErrorCancelled {
+        let nsError = error as NSError
+        if isDownloadInProgress && nsError.code == 102 {
+            isDownloadInProgress = false
+            return
+        }
+        if nsError.code != NSURLErrorCancelled {
             self.error = error
         }
+    }
+}
+
+// MARK: - WKNavigationDelegate (response) implementation
+extension OSIABWebViewModel {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+        if navigationResponse.canShowMIMEType {
+            decisionHandler(.allow)
+        } else {
+            if #available(iOS 14.5, *) {
+                decisionHandler(.download)
+            } else {
+                decisionHandler(.cancel)
+            }
+        }
+    }
+}
+
+// MARK: - WKDownloadDelegate implementation
+@available(iOS 14.5, *)
+extension OSIABWebViewModel: WKDownloadDelegate {
+
+    func download(_ download: WKDownload, decideDestinationUsing response: URLResponse, suggestedFilename: String, completionHandler: @escaping (URL?) -> Void) {
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileURL = tempDir.appendingPathComponent(suggestedFilename)
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+        downloadDestinationURL = fileURL
+        completionHandler(fileURL)
+    }
+
+    func downloadDidFinish(_ download: WKDownload) {
+        guard let fileURL = downloadDestinationURL else { return }
+        activeDownload = nil
+        DispatchQueue.main.async {
+            let activityVC = UIActivityViewController(activityItems: [fileURL], applicationActivities: nil)
+            if let rootVC = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .flatMap({ $0.windows })
+                .first(where: { $0.isKeyWindow })?.rootViewController {
+                var topVC = rootVC
+                while let presented = topVC.presentedViewController {
+                    topVC = presented
+                }
+                topVC.present(activityVC, animated: true)
+            }
+        }
+    }
+
+    func download(_ download: WKDownload, didFailWithError error: Error, resumeData: Data?) {
+        activeDownload = nil
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Handle `window.open()` and file downloads in `WKWebView` on iOS
On iOS, `WKWebView` silently ignores `window.open()` calls and cannot handle file download responses by default. This fix addresses both issues:

- Injects a WKUserScript at document start that overrides `window.open()` to navigate within the same WebView, preserving the custom User Agent
- Implements `decidePolicyFor` navigationResponse to detect non-displayable MIME types and trigger `WKDownload` (iOS 14.5+), with a `UIActivityViewController` to allow the user to save or share the downloaded file

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
Addresses: https://outsystemsrd.atlassian.net/browse/RMET-5110

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality not to work as expected)

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows the code style of this project
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
